### PR TITLE
Add extern "C"

### DIFF
--- a/include/uv_ssl_t.h
+++ b/include/uv_ssl_t.h
@@ -1,6 +1,9 @@
 #ifndef INCLUDE_UV_SSL_H_
 #define INCLUDE_UV_SSL_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* NOTE: uv.h included first, because it sets up proper includes on Windows */
 #include "uv.h"
 #include "uv_link_t.h"
@@ -14,4 +17,7 @@ UV_EXTERN uv_ssl_t* uv_ssl_create(uv_loop_t* loop, SSL* ssl, int* err);
 
 int uv_ssl_setup_recommended_secure_context(SSL_CTX* ctx);
 
+#ifdef __cplusplus
+}
+#endif
 #endif  /* INCLUDE_UV_LINK_H_ */


### PR DESCRIPTION
Similary in libuv, I wrapped the header with `extern "C"` macro to let the library be used C++ ecosystem
