### PR TITLE
Increment versions and fix compilation issues on win32 platform

### DIFF
--- a/test/src/main.c
+++ b/test/src/main.c
@@ -1,10 +1,10 @@
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+#include "test-common.h"
 #include "test-list.h"
 
 /* TODO(indutny): TAP */

--- a/test/src/test-common.h
+++ b/test/src/test-common.h
@@ -5,8 +5,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <unistd.h>
+#ifdef _WIN32
+# include <winsock2.h>
+# include <io.h>
+#else
+# include <sys/socket.h>
+# include <unistd.h>
+#endif /* _WIN32 */
 
 #include "openssl/bio.h"
 #include "openssl/err.h"


### PR DESCRIPTION
Bump libuv version to 1.12.0
Bump uv_link_t version to 1.0.4
Fix compilation issues on Windows